### PR TITLE
Adds Dockerfile to simplify compilation and testing.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:stretch
+
+# Package dependencies.
+RUN apt update && apt install -y \
+        build-essential \
+        cmake \
+        curl \
+        default-jre \
+        libsdl2-dev \
+        libsdl2-image-dev \
+        nodejs \
+        python \
+ && apt clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Emscripten is to build WebAssembly from C++.
+# https://github.com/emscripten-core/emscripten
+RUN set -x \
+ && mkdir /opt/emscripten \
+ && cd /opt/emscripten \
+ && curl -L https://github.com/emscripten-core/emsdk/tarball/master | tar xz --strip-components=1 \
+ && ./emsdk install latest \
+ && ./emsdk activate latest
+
+WORKDIR /code
+# Port running a basic web server for testing.
+EXPOSE 8080
+CMD ["/code/make_all.sh"]

--- a/README.org
+++ b/README.org
@@ -4,7 +4,16 @@ I wanted a bare-bones program for SDL2 + OpenGL 2D rendering that also compiled 
 
 * Installation
 
-The Makefile only works on Mac OS X, but the code should work on Linux and Windows and other SDL+OpenGL platforms (I haven't tried though). On Mac I installed these libraries for compilation:
+Simplest is usually using [Docker](https://www.docker.com/), once install run:
+
+#+begin_src sh
+docker build -t builder .
+docker run --rm -it -v $PWD:/code -v emcache:/root/.emscripten_cache -p 8080:8080 builder
+#+end_src
+
+Once done this would generate =bin/main=, a native Linux binary (needing SDL2 and SDL2 Image libraries), and run a server serving the WebAssembly page your can see by going to http://localhost:8080 from your machine.
+
+Another option is using the Makefile which works on Mac OS X and Linux and possibly Windows and other SDL+OpenGL platforms (I haven't tried though). On Mac I installed these libraries for compilation:
 
 #+begin_src sh
 brew install SDL2 SDL2_image emscripten

--- a/make_all.sh
+++ b/make_all.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -ex
+make
+
+source /opt/emscripten/emsdk_env.sh
+make www
+cd www
+exec emrun --no_browser --hostname 0.0.0.0 --port 8080 index.html


### PR DESCRIPTION
Updated the README so it should be self-explanatory.

The Dockerfile builds the native binary for Linux and the Wasm, and it serves the web page to test the Wasm locally.

Note that Linux binary isn't fully working for me because it says:

```
0:1(1): error: syntax error, unexpected NEW_IDENTIFIER
                                                                                                                                  
compile shader failed : No OpenGL context has been made current
```

Seems that it needs some error checking to debug these issues a bit. See also https://stackoverflow.com/questions/21354301/glsl-syntax-problems-unexpected-new-identifier